### PR TITLE
Feat(#52): argocd terraform

### DIFF
--- a/k8s/argo/apps/templates/application.yaml
+++ b/k8s/argo/apps/templates/application.yaml
@@ -5,6 +5,8 @@ kind: Application
 metadata:
   name: {{ $val.name }}{{ if $val.sub }}-{{ $val.sub }}{{ end }}-app
   namespace: argocd
+  finalizers: # 기본 동작은 포어그라운드 삭제
+    - resources-finalizer.argocd.argoproj.io
   annotations:
     argocd.argoproj.io/sync-wave: {{ $val.syncWave | quote }}
 spec:

--- a/terraform/environments/argo/main.tf
+++ b/terraform/environments/argo/main.tf
@@ -1,0 +1,9 @@
+locals {
+  root_app_path = "${path.root}/../../../k8s/argo/root"
+}
+
+module "argocd" {
+  source = "../../modules/argocd"
+
+  root_app_path = "${local.root_app_path}/dev.yaml"
+}

--- a/terraform/environments/argo/provider.tf
+++ b/terraform/environments/argo/provider.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "spot-tfstate-bucket"
+    key            = "argo/terraform.tfstate"
+    region         = "ap-northeast-2"
+    dynamodb_table = "spot-tf-locks"
+    encrypt        = true
+  }
+}
+
+locals {
+  cluster_name = "spot-dev-cluster"
+}
+
+data "aws_eks_cluster" "eks_cluster" {
+  name = local.cluster_name
+}
+
+data "aws_eks_cluster_auth" "cluster_auth" {
+  name = local.cluster_name
+}
+
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.eks_cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.cluster_auth.token
+  }
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.eks_cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster_auth.token
+  load_config_file       = false
+}

--- a/terraform/modules/argocd/main.tf
+++ b/terraform/modules/argocd/main.tf
@@ -1,0 +1,60 @@
+# =============================================================================
+# Kubectl Provider 명시
+# =============================================================================
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
+  }
+}
+
+# =============================================================================
+# ArgoCD 설치 & 배포
+# =============================================================================
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "9.5.15"
+  create_namespace = true
+  namespace        = "argocd"
+
+  values = [
+    yamlencode({
+      configs = {
+        params = {
+          "server.insecure" : true
+        }
+      }
+
+      server = {
+        ingress = {
+          enabled          = true
+          ingressClassName = "alb"
+          annotations = {
+            "alb.ingress.kubernetes.io/scheme"           = "internet-facing"
+            "alb.ingress.kubernetes.io/target-type"      = "ip"
+            "alb.ingress.kubernetes.io/listen-ports"     = "[{\"HTTP\": 80}, {\"HTTPS\":443}]"
+            "alb.ingress.kubernetes.io/ssl-redirect"     = "443"
+            "alb.ingress.kubernetes.io/group.name"       = "spot-ingress"
+            "alb.ingress.kubernetes.io/healthcheck-path" = "/"
+            "alb.ingress.kubernetes.io/success-codes"    = "200"
+          }
+          hostname = "argocd.hbksv.cloud"
+        }
+      }
+    })
+  ]
+
+}
+
+# =============================================================================
+# Root Application
+# =============================================================================
+resource "kubectl_manifest" "application" {
+  yaml_body = file(var.root_app_path)
+
+  depends_on = [helm_release.argocd]
+}

--- a/terraform/modules/argocd/variables.tf
+++ b/terraform/modules/argocd/variables.tf
@@ -1,0 +1,4 @@
+variable "root_app_path" {
+  description = "Root Application Yaml 경로"
+  type        = string
+}


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
Closes #52 

## 📄 작업 내용 요약
1. terraform/environments/argo
   - argo 스택(root module) 생성 (backend 분리, data source로 클러스터 참조)
2. terraform/modules/argocd 
   - ArgoCD 설치(helm) + root app 등록(kubectl_manifest) 모듈
3. k8s/argo/apps/templates/application.yaml
   - finalizer 추가 (destroy cascade)