### PR TITLE
feat(#61): WAF & ACM 연동 방식 수정

### DIFF
--- a/k8s/deploy/update-waf.sh
+++ b/k8s/deploy/update-waf.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Terraform 결과 가져오기
 echo "🔍 Terraform에서 WAF ARN을 가져오는 중..."
-WAF_ARN="$(cd "$SCRIPT_DIR/terraform/environments/dev" && terraform output -raw waf_acl_arn)"
+WAF_ARN="$(cd "$BASE_DIR/terraform/environments/dev" && terraform output -raw waf_acl_arn)"
 
 if ! echo "$WAF_ARN" | grep -Eq "^arn:aws:wafv2"; then
     echo "❌ 실패: 값이 일치하지 않거나 비어 있습니다."
@@ -15,7 +15,7 @@ fi
 echo "✅ 성공: $WAF_ARN"
 
 # values 파일 수정
-cd "${SCRIPT_DIR}/k8s/spot-apps"
+cd "$BASE_DIR/k8s/spot-apps"
 echo "📝 values-dev.yaml 파일을 수정하는 중..."
 
 WAF_ARN=$WAF_ARN yq -i '.ingress.annotations."alb.ingress.kubernetes.io/wafv2-acl-arn" = env(WAF_ARN)' values-dev.yaml

--- a/k8s/deploy/update-waf.sh
+++ b/k8s/deploy/update-waf.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Terraform 결과 가져오기
+echo "🔍 Terraform에서 WAF ARN을 가져오는 중..."
+WAF_ARN="$(cd "$SCRIPT_DIR/terraform/environments/dev" && terraform output -raw waf_acl_arn)"
+
+if ! echo "$WAF_ARN" | grep -Eq "^arn:aws:wafv2"; then
+    echo "❌ 실패: 값이 일치하지 않거나 비어 있습니다."
+    exit 1
+fi
+
+echo "✅ 성공: $WAF_ARN"
+
+# values 파일 수정
+cd "${SCRIPT_DIR}/k8s/spot-apps"
+echo "📝 values-dev.yaml 파일을 수정하는 중..."
+
+WAF_ARN=$WAF_ARN yq -i '.ingress.annotations."alb.ingress.kubernetes.io/wafv2-acl-arn" = env(WAF_ARN)' values-dev.yaml
+echo "✅ 성공: 아래 파일이 수정되었습니다. 커밋·PR을 진행해주세요."
+echo "$(git --no-pager diff -- values-dev.yaml)"

--- a/k8s/spot-apps/templates/ingress.yaml
+++ b/k8s/spot-apps/templates/ingress.yaml
@@ -13,20 +13,13 @@ metadata:
     {{- /* ALB healthcheck-path일 때만 sub에 정의된 경로로 덮어쓰기 */ -}}
     {{- if eq $key "alb.ingress.kubernetes.io/healthcheck-path" }}
     {{ $key }}: {{ $sub.healthPath | default "/" | quote }}
-    {{- else }}
+    {{- else if $value }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
   {{- else }}
     kubernetes.io/ingress.class: nginx
   {{- end }}
-
-  {{- /* ArgoCD */ -}}
-{{/*  {{- if $sub.annotations }}*/}}
-{{/*  {{- range $key, $value := $sub.annotations }}*/}}
-{{/*    {{ $key }}: {{ $value | quote }}*/}}
-{{/*  {{- end }}*/}}
-{{/*  {{- end }}*/}}
 
 spec:
   ingressClassName: {{ $.Values.ingress.className }}

--- a/k8s/spot-apps/templates/ingress.yaml
+++ b/k8s/spot-apps/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- /* ALB healthcheck-path일 때만 sub에 정의된 경로로 덮어쓰기 */ -}}
     {{- if eq $key "alb.ingress.kubernetes.io/healthcheck-path" }}
     {{ $key }}: {{ $sub.healthPath | default "/" | quote }}
+    {{- /* annotations의 각 key의 value가 존재하는 경우 */ -}}
     {{- else if $value }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/k8s/spot-apps/values-dev.yaml
+++ b/k8s/spot-apps/values-dev.yaml
@@ -6,7 +6,7 @@ ingress:
     enabled: true
 
   # ALB 로그 저장용 S3 버킷 이름
-  bucket: null
+  bucket: spot-dev-logs
 
   subs:
     - name: spot
@@ -19,12 +19,12 @@ ingress:
       namespace: infra
       serviceName: kafka-ui-svc
       healthPath: /
-
+    
     - name: temporal
       namespace: infra
       serviceName: temporal-ui-svc
       healthPath: /
-
+    
     - name: grafana
       namespace: monitoring
       serviceName: grafana-svc
@@ -34,18 +34,21 @@ ingress:
     # ALB 설정
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip # IP 모드
-
+    
     # 헬스 체크
     alb.ingress.kubernetes.io/healthcheck-path: /actuator/health
     alb.ingress.kubernetes.io/success-codes: '200'
-
+    
     # 모든 서비스가 하나의 ALB를 공유
     alb.ingress.kubernetes.io/group.name: spot-ingress
 
+    # WAF
+    alb.ingress.kubernetes.io/wafv2-acl-arn: ""
+    
     # HTTPS/HTTP 설정
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: '443'
-
+    
     # 태그 설정
     alb.ingress.kubernetes.io/tags: Name=spot-alb, Environment=dev,Team=spot, ManagedBy=terraform
 
@@ -54,7 +57,7 @@ domain: hbksv.cloud
 
 # [3] Deployment 설정
 global:
-  repository: ""
+  repository: 164076841262.dkr.ecr.ap-northeast-2.amazonaws.com
 
 # [4] app 목록
 apps:

--- a/k8s/spot-apps/values.yaml
+++ b/k8s/spot-apps/values.yaml
@@ -5,11 +5,6 @@ ingress:
   aws:
     enabled: false
 
-  albLogs:
-    enabled: true
-    bucket: ""
-    prefix: alb
-
   subs:
     - name: spot
       hostname: www

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -29,13 +29,21 @@
 
 ```
 1. terraform/environments/bootstrap로 이동 ⇒ terraform apply (최초 1회만, destroy 금지)
+
 2. terraform/environments/dev로 이동 ⇒ terraform apply (VPC/EKS/RDS 등 EKS 인프라)
-3. terraform/environments/argo로 이동 ⇒ terraform apply — ArgoCD 설치 + root App (여기서 ALB 생성됨)
-4. terraform/environments/dev/terraform.tfvars의 alb_dns_name 변수에 ALB DNS 값을 기입
-5. terraform/environments/dev로 이동 ⇒ terraform apply 다시 실행 (Route53 레코드 생성)
+
+3. k8s/deploy의 update-waf.sh 실행 ⇒ diff 확인 ⇒ PR로 dev merge (WAF ARN 값 수정 및 git 업데이트)
+
+4. terraform/environments/argo로 이동 ⇒ terraform apply — ArgoCD 설치 + root App (여기서 ALB 생성됨)
+
+5. terraform/environments/dev/terraform.tfvars의 alb_dns_name 변수에 ALB DNS 값을 기입
+
+6. terraform/environments/dev로 이동 ⇒ terraform apply 다시 실행 (Route53 레코드 생성)
 ```
 
-> ⚠️ external-dns 도입 시 4~5번 단계는 제거 예정
+> ⚠️ external-dns 도입 시 **5~6번 단계**는 제거 예정
+>
+> ⚠️ **3번(WAF ARN 갱신·머지)은 반드시 4번(argo apply)보다 먼저 완료해야 한다.** spot-app이 첫 sync 진행 시, 새 WAF ARN이 dev 브랜치에 merge돼 있지 않으면 에러가 발생한다. 이 경우 LBC가 존재하지 않는 WAF에 associate를 시도해 spot-ingress 그룹 전체가 reconcile 400 루프에 빠지고, 심하면 finalizer가 멈춰 이후 destroy까지 블로킹된다.
 
 ### Destroy
 


### PR DESCRIPTION
## 📎 Issue 번호
Closes #61

## 📄 작업 내용 요약

### **deploy-dev.sh**
- deploy-dev.sh가 배포 시 `--set`으로 주입하던 ingress 값들을 git(values-dev.yaml)에 선언하도록  수정

### **값별 처리**
- **ACM 인증서**: `certificate-arn` 명시 제거 → AWS LBC의 host 기반 auto-discovery 활용(rules host `*.hbksv.cloud` ↔ 와일드카드 인증서 자동 매칭)
- **S3 버킷 / ECR 레지스트리**: 재구축해도 값이 변하지 않아 values-dev.yaml에 하드코딩
- **WAF ACL ARN**: 재구축 시 값이 바뀌어 하드코딩 불가 → 빈 값으로 커밋
   - `update-waf.sh`가 `terraform output` → yq로 채운 뒤 PR로 dev 반영

### **k8s/spot-apps/templates/ingress.yaml**
- ingress 템플릿: 어노테이션 값이 없으면(null, "") 해당 키를 렌더하지 않음(`else if $value`)

### **이 PR에서 하지 않은 것**
- deploy-dev.sh `--set` 4줄 제거는 #67 에서 진행 예정
- WAF & ACM 검증은 #62 에서 진행 예정
