### PR TITLE
feat(#68): S3 버킷 보안 옵션 추가

### DIFF
--- a/terraform/environments/bootstrap/main.tf
+++ b/terraform/environments/bootstrap/main.tf
@@ -34,6 +34,53 @@ resource "aws_s3_bucket_versioning" "tfstate" {
   }
 }
 
+resource "aws_s3_bucket_policy" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    # HTTPS 요청만 허용
+    Statement = [
+      {
+        Sid    = "AllowSSLRequestsOnly",
+        Action = "s3:*",
+        Effect = "Deny",
+        Resource = [
+          aws_s3_bucket.tfstate.arn,
+          "${aws_s3_bucket.tfstate.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        },
+        Principal = "*"
+      }
+    ]
+  })
+}
+
+# S3 퍼블릭 액세스 차단 설정
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    blocked_encryption_types = ["SSE-C"]
+  }
+}
+
 resource "aws_dynamodb_table" "tf_locks" {
   name         = "spot-tf-locks"
   billing_mode = "PAY_PER_REQUEST"

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,15 +1,14 @@
 # =============================================================================
 # S3
 # =============================================================================
-# state 파일 저장
+# log 파일 저장
 resource "aws_s3_bucket" "logs" {
   bucket        = "${var.name_prefix}-logs"
   force_destroy = true
   tags          = merge(var.common_tags, { Name = "${var.name_prefix}-s3-logs" })
 }
 
-# state 파일 실수로 덮어쓰면 복구 불가능
-# 버저닝 활성화하면 이전 버전으로 복구 가능
+# log 파일 실수로 지웠을 때 복구
 resource "aws_s3_bucket_versioning" "logs" {
   bucket = aws_s3_bucket.logs.id
   versioning_configuration {
@@ -27,7 +26,18 @@ resource "aws_s3_bucket_public_access_block" "logs" {
   restrict_public_buckets = true
 }
 
-# 로그 자동 삭제 정책
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    blocked_encryption_types = ["SSE-C"]
+  }
+}
+
+# 로그 수명 주기 정책 - 오래된 로그 자동 삭제
 resource "aws_s3_bucket_lifecycle_configuration" "logs" {
   bucket = aws_s3_bucket.logs.id
 
@@ -49,6 +59,23 @@ resource "aws_s3_bucket_policy" "logs" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
+      # HTTPS 요청만 허용
+      {
+        Sid    = "AllowSSLRequestsOnly",
+        Action = "s3:*",
+        Effect = "Deny",
+        Resource = [
+          aws_s3_bucket.logs.arn,
+          "${aws_s3_bucket.logs.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        },
+        Principal = "*"
+      },
+
       # ALB Access Log
       {
         Effect = "Allow"


### PR DESCRIPTION
## 📎 Issue 번호
closed #68 

## 📄 작업 내용 요약
### 변경 사항

**`environments/bootstrap` (tfstate 버킷)**
- `aws_s3_bucket_public_access_block` 추가 — 옵션 4개 명시
- `aws_s3_bucket_server_side_encryption_configuration` 추가 — AES256, SSE-C 차단
- `aws_s3_bucket_policy` 추가 — `aws:SecureTransport = false`일 때 Deny (HTTPS 강제)

**`modules/s3` (로그 버킷)**
- `aws_s3_bucket_server_side_encryption_configuration` 추가 (누락 상태였음)
- 기존 버킷 정책에 HTTPS 강제 Deny statement 추가
- bootstrap에서 복사되어 남아 있던 잘못된 주석 수정 (로그 버킷인데 "state 파일" 서술)