### PR TITLE
refactor(#70): bootstrap 파일 분리

### DIFF
--- a/terraform/environments/argo/provider.tf
+++ b/terraform/environments/argo/provider.tf
@@ -17,11 +17,15 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "spot-tfstate-bucket"
-    key            = "argo/terraform.tfstate"
-    region         = "ap-northeast-2"
+    bucket = "spot-tfstate-bucket"
+    key    = "argo/terraform.tfstate"
+    region = "ap-northeast-2"
+
+    # KMS key로 암호화 활성
+    encrypt    = true
+    kms_key_id = "arn:aws:kms:ap-northeast-2:164076841262:alias/spot-tfstate"
+
     dynamodb_table = "spot-tf-locks"
-    encrypt        = true
   }
 }
 

--- a/terraform/environments/bootstrap/backend.tf
+++ b/terraform/environments/bootstrap/backend.tf
@@ -62,8 +62,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_alias.tfstate.name
     }
+
+    bucket_key_enabled       = true
     blocked_encryption_types = ["SSE-C"]
   }
 }
@@ -80,7 +83,7 @@ resource "aws_dynamodb_table" "tf_locks" {
 
   tags = {
     Name        = "Terraform State Lock Table"
-    Environment = "global"
+    Environment = "Global"
     Project     = "spot"
   }
 }

--- a/terraform/environments/bootstrap/backend.tf
+++ b/terraform/environments/bootstrap/backend.tf
@@ -1,16 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = "ap-northeast-2"
-}
-
 # state 파일 저장
 resource "aws_s3_bucket" "tfstate" {
   bucket = "spot-tfstate-bucket"

--- a/terraform/environments/bootstrap/kms.tf
+++ b/terraform/environments/bootstrap/kms.tf
@@ -1,0 +1,33 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "tfstate" {
+  description             = "KMS key for spot-tfstate-bucket"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "spot-tfstate-key-policy"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = {
+    Purpose     = "spot-tfstate-encryption"
+    Environment = "Global"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_kms_alias" "tfstate" {
+  name          = "alias/spot-tfstate"
+  target_key_id = aws_kms_key.tfstate.key_id
+}

--- a/terraform/environments/bootstrap/providers.tf
+++ b/terraform/environments/bootstrap/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-2"
+}

--- a/terraform/environments/dev/providers.tf
+++ b/terraform/environments/dev/providers.tf
@@ -17,11 +17,15 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "spot-tfstate-bucket"
-    key            = "dev/terraform.tfstate"
-    region         = "ap-northeast-2"
+    bucket = "spot-tfstate-bucket"
+    key    = "dev/terraform.tfstate"
+    region = "ap-northeast-2"
+
+    # KMS key로 암호화 활성
+    encrypt    = true
+    kms_key_id = "arn:aws:kms:ap-northeast-2:164076841262:alias/spot-tfstate"
+
     dynamodb_table = "spot-tf-locks"
-    encrypt        = true
   }
 }
 


### PR DESCRIPTION
## 📎 Issue 번호
closed #70

## 📄 작업 내용 요약

tfstate 암호화를 SSE-S3(AES256) → **SSE-KMS(고객 관리 키)** 로 전환
버킷 읽기 권한과 복호화 권한을 분리해, 자격증명이 유출돼도 KMS 권한 없이는 state를 열 수 없게 함
(tfstate에는 RDS 비밀번호·JWT 시크릿이 평문으로 들어있음)

### 변경 내용
- **KMS 키 생성** (`bootstrap/kms.tf`)
  - `deletion_window_in_days = 30` — 실수로 삭제 시 되돌릴 창을 최대로
  - `enable_key_rotation = true` — 옛 키 자료가 보관되므로 기존 암호문은 계속 복호화됨
  - 키 정책은 **계정 루트 `kms:*` 1문장만**. KMS는 키 정책에 없는 주체를 IAM 관리자라도 거부하므로 루트 Allow가 필수
- **버킷 기본 암호화 전환** (`bootstrap/backend.tf`): `AES256` → `aws:kms` + `bucket_key_enabled = true`
- **backend 설정** (`dev/providers.tf`, `argo/provider.tf`): `kms_key_id` 추가
- **bootstrap 파일 분리** (별도 커밋, 동작 변화 없음): `main.tf` → `providers.tf` / `backend.tf` / `kms.tf`