### PR TITLE
Fix(#73): local entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ PostgreSQL, Redis, Kafka(KRaft 3-broker), Kafka Connect, Temporal 및 전체 서
 
 `docker`, `k3d`, `kubectl`, `helm` 이 설치돼 있어야 합니다.
 
-**1. 시크릿 파일 생성**
+#### 1. 시크릿 파일 생성
 
 `k8s/base/secret/.env` 를 만들고 아래 6개 키에 값을 채웁니다 (gitignore 대상).
 
@@ -62,48 +62,52 @@ TOSS_SECRET_KEY=
 
 > DB 주소·Kafka 주소·Feign URL 등 나머지 설정값은 [`k8s/overlays/local/config/env-config/configs.env`](./k8s/overlays/local/config/env-config/configs.env)에 이미 커밋돼 있으므로 따로 작성할 필요가 없습니다.
 
-**2. 실행**
+#### 2. 실행
+
+> ⚠️ 로컬은 셸 스크립트 실행으로 ArgoCD는 사용하지 않습니다. (Dev/Prod는 GitOps)
 
 ```bash
+# 전체 실행
 ./run_k3d.sh
+
+# 부분 실행 예시
+./run_k3d.sh --cluster
 ```
 
-k3d 클러스터 생성 → 서비스 이미지 빌드·push → 인프라·모니터링·애플리케이션 배포까지 한 번에 진행됩니다. (ArgoCD는 사용하지 않습니다 — 로컬은 셸 스크립트, Dev/Prod는 GitOps)
+**⚙️ 부분 실행 옵션**
 
-부분 실행 옵션:
+| 옵션                                  | 동작                                                                    |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| _(없음)_                              | 전체 실행                                                               |
+| `--no-monitoring`                     | 모니터링 스택을 제외하고 전체 실행                                      |
+| `--cluster`                           | k3d 클러스터만 재생성 — 레지스트리도 함께 삭제되므로 이미지 재빌드 필요 |
+| `--build`                             | 서비스 이미지 빌드·push만 실행                                          |
+| `--bootstrap`                         | 네임스페이스·ConfigMap·Secret 생성 + ingress-nginx 설치                 |
+| `--infra` / `--monitoring` / `--spot` | 해당 네임스페이스만 재배포                                              |
 
-| 옵션                                  | 동작                                         |
-| ------------------------------------- | -------------------------------------------- |
-| _(없음)_                              | 전체 실행                                    |
-| `--no-monitoring`                     | 모니터링 스택을 제외하고 전체 실행           |
-| `--cluster`                           | k3d 클러스터만 생성                          |
-| `--build`                             | 서비스 이미지 빌드·push만 실행               |
-| `--infra` / `--monitoring` / `--spot` | 해당 네임스페이스만 재배포                   |
-| `--mini`                              | 원격 레지스트리로 빌드 후 배포 (원격 구성용) |
+#### 3. hosts 파일 등록
 
-**3. hosts 파일 등록**
-
-배포된 서비스는 Ingress 도메인으로 접근하기 때문에 hosts 파일 등록이 필수입니다.
+> ⚠️ 배포된 서비스는 Ingress 도메인으로 접근하기 때문에 hosts 파일 등록이 필수입니다.
 
 - Windows
 
-```
-# 1. 메모장을 "관리자 권한으로 실행"한 뒤, 아래 파일을 엽니다
-C:\Windows\System32\drivers\etc\hosts
+  ```
+  # 1. 메모장을 "관리자 권한으로 실행"한 뒤, 아래 파일을 엽니다
+  C:\Windows\System32\drivers\etc\hosts
 
-# 2. 파일 맨 아래에 아래 내용을 추가하고 저장합니다
-127.0.0.1 www.spot kafka.spot temporal.spot grafana.spot
-```
+  # 2. 파일 맨 아래에 아래 내용을 추가하고 저장합니다
+  127.0.0.1 www.spot kafka.spot temporal.spot grafana.spot
+  ```
 
 - macOS·Linux
 
-```bash
-# 1. 터미널에서 hosts 파일을 엽니다
-sudo vi /etc/hosts
+  ```bash
+  # 1. 터미널에서 hosts 파일을 엽니다
+  sudo vi /etc/hosts
 
-# 2. 파일 맨 아래에 아래 내용을 추가하고 저장합니다
-127.0.0.1 www.spot kafka.spot temporal.spot grafana.spot
-```
+  # 2. 파일 맨 아래에 아래 내용을 추가하고 저장합니다
+  127.0.0.1 www.spot kafka.spot temporal.spot grafana.spot
+  ```
 
 | 서비스      | 주소                 |
 | ----------- | -------------------- |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - Java 21 / Spring Boot 3.5.9 / Spring Cloud 2025.0.1
 - PostgreSQL, Redis, Kafka, Temporal
-- Kubernetes 1.35 (EKS / k3d), Terraform, Helm, Kustomize, ArgoCD (GitOps)
+- Kubernetes (EKS 1.35 / 로컬 k3d 1.30), Terraform, Helm, Kustomize, ArgoCD (GitOps)
 - Prometheus, Grafana, Loki, fluent-bit
 - k6 (부하 테스트)
 
@@ -38,77 +38,97 @@ PostgreSQL, Redis, Kafka(KRaft 3-broker), Kafka Connect, Temporal 및 전체 서
 
 ### 로컬 k3d 실행
 
-```bash
-./k8s/bootstrap/k3d-cluster-init.sh  # k3d 클러스터 생성
-./k8s/bootstrap/deploy-argo.sh       # ArgoCD 설치 + root App 배포 (App-of-Apps)
-./k8s/deploy/local-build-img.sh      # 서비스 이미지 빌드 및 로컬 레지스트리 push
-```
+`docker`, `k3d`, `kubectl`, `helm` 이 설치돼 있어야 합니다.
 
-> ⚠️ `deploy-argo.sh` 실행 전에 `k8s/base/common-config/.env` 파일이 필요합니다 (Secret 생성용, gitignore 대상). 아래 키에 값을 채워 생성하세요.
+**1. 시크릿 파일 생성**
 
-<details>
-<summary><code>.env</code> 예시 (값은 직접 채워주세요)</summary>
+`k8s/base/secret/.env` 를 만들고 아래 6개 키에 값을 채웁니다 (gitignore 대상).
 
 ```ini
 # [PostgreSQL]
-SPRING_DATASOURCE_URL=
 SPRING_DATASOURCE_USERNAME=
 SPRING_DATASOURCE_PASSWORD=
-DB_HOST=
-DB_NAME=
-
-# [Redis]
-SPRING_DATA_REDIS_HOST=
-SPRING_DATA_REDIS_PORT=
-
-# [Kafka]
-KAFKA_BOOTSTRAP_SERVERS=
-
-# [Temporal]
-SPRING_TEMPORAL_CONNECTION_TARGET=
 
 # [JWT]
 SPRING_JWT_SECRET=
-SPRING_JWT_EXPIRE_MS=
 
 # [EMAIL]
 EMAIL_USERNAME=
 EMAIL_PASSWORD=
 
 # [TOSS]
-TOSS_CUSTOMER_KEY=
 TOSS_SECRET_KEY=
-
-# [Feign]
-FEIGN_USER_URL=
-FEIGN_ORDER_URL=
-FEIGN_STORE_URL=
-FEIGN_PAYMENT_URL=
-
-SPOT_USER_URI=
-SPOT_STORE_URI=
-SPOT_ORDER_URI=
-SPOT_PAYMENT_URI=
 ```
 
-</details>
+> DB 주소·Kafka 주소·Feign URL 등 나머지 설정값은 [`k8s/overlays/local/config/env-config/configs.env`](./k8s/overlays/local/config/env-config/configs.env)에 이미 커밋돼 있으므로 따로 작성할 필요가 없습니다.
+
+**2. 실행**
+
+```bash
+./run_k3d.sh
+```
+
+k3d 클러스터 생성 → 서비스 이미지 빌드·push → 인프라·모니터링·애플리케이션 배포까지 한 번에 진행됩니다. (ArgoCD는 사용하지 않습니다 — 로컬은 셸 스크립트, Dev/Prod는 GitOps)
+
+부분 실행 옵션:
+
+| 옵션                                  | 동작                                         |
+| ------------------------------------- | -------------------------------------------- |
+| _(없음)_                              | 전체 실행                                    |
+| `--no-monitoring`                     | 모니터링 스택을 제외하고 전체 실행           |
+| `--cluster`                           | k3d 클러스터만 생성                          |
+| `--build`                             | 서비스 이미지 빌드·push만 실행               |
+| `--infra` / `--monitoring` / `--spot` | 해당 네임스페이스만 재배포                   |
+| `--mini`                              | 원격 레지스트리로 빌드 후 배포 (원격 구성용) |
+
+**3. hosts 파일 등록**
+
+배포된 서비스는 Ingress 도메인으로 접근하기 때문에 hosts 파일 등록이 필수입니다.
+
+- Windows
+
+```
+# 1. 메모장을 "관리자 권한으로 실행"한 뒤, 아래 파일을 엽니다
+C:\Windows\System32\drivers\etc\hosts
+
+# 2. 파일 맨 아래에 아래 내용을 추가하고 저장합니다
+127.0.0.1 www.spot kafka.spot temporal.spot grafana.spot
+```
+
+- macOS·Linux
+
+```bash
+# 1. 터미널에서 hosts 파일을 엽니다
+sudo vi /etc/hosts
+
+# 2. 파일 맨 아래에 아래 내용을 추가하고 저장합니다
+127.0.0.1 www.spot kafka.spot temporal.spot grafana.spot
+```
+
+| 서비스      | 주소                 |
+| ----------- | -------------------- |
+| Gateway API | http://www.spot      |
+| Kafka UI    | http://kafka.spot    |
+| Temporal UI | http://temporal.spot |
+| Grafana     | http://grafana.spot  |
 
 > 더미 데이터와 함께 실행하려면 [data/README.md](./data/README.md)를 참고하세요.
 
 ## Project Structure
 
-| 디렉터리                                                   | 설명                                                                                                      |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `spot-gateway`                                             | Spring Cloud Gateway (라우팅, 인증/인가)                                                                  |
-| [`spot-user`](./spot-user/README.md) / [`spot-store`](./spot-store/README.md) / [`spot-order`](./spot-order/README.md) / [`spot-payment`](./spot-payment/README.md) | 도메인 서비스 (링크 = 도메인별 README)                                                                    |
-| `spot-mono`                                                | 모놀리식 통합 모듈                                                                                        |
-| `FE`                                                       | 프론트엔드                                                                                                |
-| `config`                                                   | 공통 Spring 설정(yml) — Docker Compose 실행 시 사용 (`./config:/config` 마운트)                           |
-| `k8s`                                                      | Kustomize(base/overlays) + Helm 차트(spot-apps), ArgoCD App-of-Apps(argo/), k3d 부트스트랩, 배포 스크립트 |
-| `k8s/base/common-config`                                   | 클러스터용 설정·시크릿 소스 — k3d 실행 시 ConfigMap·Secret으로 생성 (kustomize generator)                 |
-| `terraform`                                                | AWS 인프라 IaC (modules + environments) — [실행 가이드](./terraform/README.md)                            |
-| `k6`                                                       | 부하 테스트 스크립트                                                                                      |
-| `docs`                                                     | 기능 문서                                                                                                 |
+| 디렉터리                                                                                                                                                            | 설명                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `spot-gateway`                                                                                                                                                      | Spring Cloud Gateway (라우팅, 인증/인가)                                                                                           |
+| [`spot-user`](./spot-user/README.md) / [`spot-store`](./spot-store/README.md) / [`spot-order`](./spot-order/README.md) / [`spot-payment`](./spot-payment/README.md) | 도메인 서비스 (링크 = 도메인별 README)                                                                                             |
+| `spot-mono`                                                                                                                                                         | 모놀리식 통합 모듈                                                                                                                 |
+| `FE`                                                                                                                                                                | 프론트엔드                                                                                                                         |
+| `config`                                                                                                                                                            | 공통 Spring 설정(yml) — Docker Compose 실행 시 사용 (`./config:/config` 마운트)                                                    |
+| `k8s`                                                                                                                                                               | Kustomize(base/overlays) + Helm 차트(spot-apps), ArgoCD App-of-Apps(`argo/` — Dev/Prod GitOps 전용), k3d 부트스트랩, 배포 스크립트 |
+| `k8s/base/secret`                                                                                                                                                   | `.env` → Secret 생성 (kustomize secretGenerator, `.env`는 gitignore 대상)                                                          |
+| `k8s/overlays/local` · `k8s/overlays/dev`                                                                                                                           | 환경별 매니페스트 (config / infra / monitoring)                                                                                    |
+| `terraform`                                                                                                                                                         | AWS 인프라 IaC (modules + environments) — [실행 가이드](./terraform/README.md)                                                     |
+| `k6`                                                                                                                                                                | 부하 테스트 스크립트                                                                                                               |
+| `docs`                                                                                                                                                              | 기능 문서                                                                                                                          |
 
 ## Application Flow
 
@@ -172,6 +192,10 @@ User → Route 53 → ALB (AWS Load Balancer Controller) → Spring Cloud Gatewa
   - App-of-Apps 패턴으로 `k8s/`의 매니페스트를 pull 방식으로 동기화
   - Terraform(`environments/argo`)으로 부트스트랩
 - **GitHub Actions**: dev 머지 시 변경된 서비스만 빌드해 ECR push (OIDC 인증) — 클러스터 반영은 ArgoCD 담당
+- **External Secrets Operator**: Parameter Store의 값을 클러스터 Secret으로 동기화 (`ClusterSecretStore` + `ExternalSecret`)
+- **external-dns**: Ingress 생성 시 Route 53 레코드 자동 등록
+
+> GitOps는 Dev/Prod 환경에만 적용됩니다. 로컬 k3d는 셸 스크립트(`run_k3d.sh`)로 배포합니다.
 
 ### 데이터베이스 및 메시징
 
@@ -182,12 +206,14 @@ User → Route 53 → ALB (AWS Load Balancer Controller) → Spring Cloud Gatewa
 
 ### 보안 및 관리
 
-| 서비스          | 용도                                             |
-| --------------- | ------------------------------------------------ |
-| IAM             | 접근 권한 관리 (GitHub Actions OIDC 포함)        |
-| WAF             | 웹 방화벽 (rate limiting)                        |
-| Secrets Manager | RDS 마스터 암호 관리 (앱 시크릿은 ESO 도입 예정) |
-| ACM             | TLS 인증서 관리                                  |
+| 서비스          | 용도                                                                         |
+| --------------- | ---------------------------------------------------------------------------- |
+| IAM             | 접근 권한 관리 (GitHub Actions OIDC 포함)                                    |
+| WAF             | 웹 방화벽 (rate limiting)                                                    |
+| Secrets Manager | RDS 마스터 암호 관리                                                         |
+| Parameter Store | 앱 시크릿 저장 — External Secrets Operator(ESO)가 클러스터 Secret으로 동기화 |
+| KMS             | tfstate 암호화 (S3 backend, 전 환경 공용 키)                                 |
+| ACM             | TLS 인증서 관리                                                              |
 
 ### 모니터링 및 로깅
 

--- a/k8s/bootstrap/k3d-cluster-init.sh
+++ b/k8s/bootstrap/k3d-cluster-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Colors for output
+# output 색상
 RED='\033[1;31m'
 PURPLE='\033[95m'
 YELLOW='\033[33m'
@@ -25,7 +25,7 @@ REGISTRY_NAME="spot-registry.localhost"
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 PUBLIC_IP=$(curl -s ifconfig.me)
-API_PORT=$K8S_API_PORT
+API_PORT=${K8S_API_PORT:-6443}
 
 # 2. 설치 여부 확인
 log_info "필수 도구 설치 여부를 확인합니다..."

--- a/k8s/deploy/deploy-local.sh
+++ b/k8s/deploy/deploy-local.sh
@@ -161,12 +161,10 @@ main() {
     local run_monitoring=true
 
     case "${1:-}" in
-        --infra)
-            deploy_infra; exit 0 ;;
-        --monitoring)
-            deploy_monitoring; exit 0 ;;
-        --spot)
-            deploy_spot; exit 0 ;;
+        --bootstrap) bootstrap; exit 0 ;;
+        --infra) deploy_infra; exit 0 ;;
+        --monitoring) deploy_monitoring; exit 0 ;;
+        --spot) deploy_spot; exit 0 ;;
         --no-monitoring) run_monitoring=false ;;
         "")              ;;
         *) log_error "알 수 없는 옵션: $1"; exit 1 ;;

--- a/k8s/deploy/local-build-img.sh
+++ b/k8s/deploy/local-build-img.sh
@@ -6,7 +6,7 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REGISTRY_NAME="spot-registry.localhost"
 REGISTRY_PORT="5000"
 
-# Colors for output
+# output 색상
 RED='\033[1;31m'
 PURPLE='\033[95m'
 YELLOW='\033[33m'
@@ -23,25 +23,35 @@ log_error() {
 log_info() {
     echo -e "${PURPLE}[INFO] ☑️ ${NC} $1"
 }
+MINI=false
 
-# 기존 터널 종료
-if netstat -ano | grep -q ${REGISTRY_PORT}; then
-    log_warn "이미 ${REGISTRY_PORT} 포트가 사용 중입니다. 기존 SSH 터널을 종료합니다..."
-    taskkill //F //IM ssh.exe 2>/dev/null || true
-    sleep 2
-fi
+case "${1:-}" in
+    --mini)
+        MINI=true ;;
+    "")              ;;
+    *) log_error "알 수 없는 옵션: $1"; exit 1 ;;
+esac
 
-# ssh 포트 포워딩
-log_info "미니PC 레지스트리로 포트 포워딩을 시작합니다..."
+if [[ "$MINI" == true ]]; then
+    # 기존 터널 종료
+    if nc -z localhost "$REGISTRY_PORT"; then
+        log_warn "이미 ${REGISTRY_PORT} 포트가 사용 중입니다. 기존 SSH 터널을 종료합니다..."
+        taskkill //F //IM ssh.exe 2>/dev/null || true
+        sleep 2
+    fi
 
-if ! nc -z localhost "$REGISTRY_PORT" 2>/dev/null; then
-    ssh -f -N -L ${REGISTRY_PORT}:localhost:${REGISTRY_PORT} mini-pc
-    log_info "SSH 터널링 성공!"
+    # ssh 포트 포워딩
+    log_info "미니PC 레지스트리로 포트 포워딩을 시작합니다..."
+
+    if ! nc -z localhost "$REGISTRY_PORT" 2>/dev/null; then
+        ssh -f -N -L ${REGISTRY_PORT}:localhost:${REGISTRY_PORT} mini-pc
+        log_info "SSH 터널링 성공!"
+    fi
+
+    log_info "미니PC Docker 레지스트리로 이미지 빌드를 시작합니다..."
 else
-    log_warn "이미 5000 포트가 사용 중입니다."
+    log_info "로컬 Docker 레지스트리로 이미지 빌드를 시작합니다..."
 fi
-
-log_info "로컬 도커 레지스트리로 이미지 빌드를 시작합니다..."
 
 SERVICES=("spot-gateway" "spot-user" "spot-store" "spot-order" "spot-payment")
 
@@ -68,7 +78,9 @@ for service in "${SERVICES[@]}"; do
 
     if [ "$PUSH_SUCCESS" = false ]; then
         log_error "$service 이미지 Push에 실패했습니다."
-        taskkill //F //IM ssh.exe 2>/dev/null || true
+        if [[ "$MINI" == true ]]; then
+            taskkill //F //IM ssh.exe 2>/dev/null || true
+        fi
         exit 1
     fi
 
@@ -77,5 +89,7 @@ done
 
 log_info "모든 Spot 서비스의 이미지 빌드 및 Push가 완료되었습니다!"
 
-log_info "백그라운로 실행한 터미널을 종료합니다."
-taskkill //F //IM ssh.exe 2>/dev/null || true
+if [[ "$MINI" == true ]]; then
+    log_info "백그라운드로 실행한 터미널을 종료합니다."
+    taskkill //F //IM ssh.exe 2>/dev/null || true
+fi

--- a/k8s/deploy/local-build-img.sh
+++ b/k8s/deploy/local-build-img.sh
@@ -32,9 +32,13 @@ case "${1:-}" in
     *) log_error "알 수 없는 옵션: $1"; exit 1 ;;
 esac
 
+is_port_open() {
+    (echo > /dev/tcp/127.0.0.1/"$REGISTRY_PORT") 2>/dev/null
+}
+
 if [[ "$MINI" == true ]]; then
     # 기존 터널 종료
-    if nc -z localhost "$REGISTRY_PORT"; then
+    if is_port_open; then
         log_warn "이미 ${REGISTRY_PORT} 포트가 사용 중입니다. 기존 SSH 터널을 종료합니다..."
         taskkill //F //IM ssh.exe 2>/dev/null || true
         sleep 2
@@ -42,11 +46,8 @@ if [[ "$MINI" == true ]]; then
 
     # ssh 포트 포워딩
     log_info "미니PC 레지스트리로 포트 포워딩을 시작합니다..."
-
-    if ! nc -z localhost "$REGISTRY_PORT" 2>/dev/null; then
-        ssh -f -N -L ${REGISTRY_PORT}:localhost:${REGISTRY_PORT} mini-pc
-        log_info "SSH 터널링 성공!"
-    fi
+    ssh -f -N -o ExitOnForwardFailure=yes -L ${REGISTRY_PORT}:localhost:${REGISTRY_PORT} mini-pc
+    log_info "SSH 터널링 성공!"
 
     log_info "미니PC Docker 레지스트리로 이미지 빌드를 시작합니다..."
 else

--- a/run_k3d.sh
+++ b/run_k3d.sh
@@ -1,294 +1,85 @@
 #!/bin/bash
-
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CLUSTER_NAME="spot-cluster"
-REGISTRY_NAME="127.0.0.1"
-REGISTRY_PORT="5111"
-
-# 로컬 레지스트리는 프록시 우회
-export NO_PROXY="${NO_PROXY:-},localhost,127.0.0.1,spot-registry.localhost,*.localhost"
-export no_proxy="${no_proxy:-},localhost,127.0.0.1,spot-registry.localhost,*.localhost"
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
+# output 색상
+RED='\033[1;31m'
+PURPLE='\033[95m'
+YELLOW='\033[33m'
 NC='\033[0m' # No Color
 
-log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
-}
+log_warn() { echo -e "${YELLOW}[WARN] ⚠️ ${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR] ❌ ${NC} $1"; }
+log_info() { echo -e "${PURPLE}[INFO] ☑️ ${NC} $1"; }
 
-log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-check_prerequisites() {
-    log_info "Checking prerequisites..."
-
-    if ! command -v docker &> /dev/null; then
-        log_error "Docker is not installed. Please install Docker first."
-        exit 1
-    fi
-
-    if ! command -v k3d &> /dev/null; then
-        log_warn "k3d is not installed. Installing k3d..."
-        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-    fi
-
-    if ! command -v kubectl &> /dev/null; then
-        log_error "kubectl is not installed. Please install kubectl first."
-        exit 1
-    fi
-
-    if ! command -v kustomize &> /dev/null; then
-        log_warn "kustomize is not installed. Installing kustomize..."
-        brew install kustomize
-    fi
-
-    if ! command -v helm &> /dev/null; then
-        log_warn "helm is not installed. Installing helm..."
-        brew install helm
-    fi
-
-    log_info "All prerequisites are met."
-}
-
-cleanup_existing() {
-    log_info "Cleaning up existing resources..."
-
-    if [ -f "$SCRIPT_DIR/docker-compose.yaml" ]; then
-        docker compose -f "$SCRIPT_DIR/docker-compose.yaml" down --remove-orphans 2>/dev/null || true
-    fi
-    
-    log_info "Starting essential infrastructure (DB, Redis) via Docker Compose..."
-    docker compose -f "$SCRIPT_DIR/docker-compose.yaml" up -d db redis
-
-    if k3d cluster list | grep -q "$CLUSTER_NAME"; then
-        log_info "Deleting existing k3d cluster: $CLUSTER_NAME"
-        k3d cluster delete "$CLUSTER_NAME"
-    fi
-
-    if docker ps -a | grep -q "k3d-$REGISTRY_NAME"; then
-        log_info "Removing existing registry..."
-        docker rm -f "k3d-$REGISTRY_NAME" 2>/dev/null || true
-    fi
-}
-
-create_cluster() {
-    log_info "Creating k3d cluster with config..."
-    k3d cluster create --config "$SCRIPT_DIR/infra/k3d/cluster-config.yaml"
-
-    log_info "Waiting for cluster to be ready..."
-    kubectl wait --for=condition=ready node --all --timeout=180s
-
-    log_info "Cluster created successfully!"
-
-    log_info "Creating Namespaces..."
-
-    kubectl apply -f "$SCRIPT_DIR/infra/k8s/base/namespace.yaml"
-
-    log_info "Creating Namespaces..."
-}
-
-build_and_push_images() {
-    log_info "Building and pushing Docker images to local registry..."
-
-    SERVICES=("spot-gateway" "spot-user" "spot-store" "spot-order" "spot-payment")
-  
-    log_info "Building Kafka Connect with Debezium..."
-    docker build -t "$REGISTRY_NAME:$REGISTRY_PORT/spot-connect-custom:latest" "$SCRIPT_DIR/infra/k8s/base/kafka/"
-    n=0
-    until [ $n -ge 3 ]; do
-        docker push "$REGISTRY_NAME:$REGISTRY_PORT/spot-connect-custom:latest" && break
-        n=$((n+1))
-        log_warn "Push failed for spot-connect-custom. Retrying ($n/3)..."
-        sleep 2
-    done
-    
-    for service in "${SERVICES[@]}"; do
-        log_info "Building $service..."
-        (cd "$SCRIPT_DIR/$service" && ./gradlew bootJar -x test)
-        
-        docker build -t "$REGISTRY_NAME:$REGISTRY_PORT/$service:latest" "$SCRIPT_DIR/$service"
-
-        n=0
-        until [ $n -ge 3 ]; do
-            docker push "$REGISTRY_NAME:$REGISTRY_PORT/$service:latest" && break
-            n=$((n+1))
-            log_warn "Push failed for $service. Retrying ($n/3)..."
-            sleep 2
-        done
-        log_info "$service image pushed successfully!"
-    done
-  }
-
-install_argocd() {
-    log_info "Installing ArgoCD..."
-
-    kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
-
-    log_info "Waiting for ArgoCD to be ready..."
-    kubectl wait --for=condition=available deployment/argocd-server -n argocd --timeout=300s
-
-    if [ -f "$SCRIPT_DIR/infra/argo/argocd-ingress.yaml" ]; then
-        kubectl apply -f "$SCRIPT_DIR/infra/argo/argocd-ingress.yaml"
-    fi
-
-    log_info "ArgoCD installed successfully!"
-}
-
-install_prometheus() {
-    log_info "Installing Prometheus (kube-prometheus-stack) via Helm..."
-
-    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
-    helm repo update
-
-    VALUES_FILE="$SCRIPT_DIR/infra/k8s/base/monitoring/prometheus/value.yaml"
-    if [ ! -f "$VALUES_FILE" ]; then
-        log_error "Prometheus values file not found: $VALUES_FILE"
-        exit 1
-    fi
-
-    helm upgrade --install prom prometheus-community/kube-prometheus-stack \
-        -n monitoring \
-        -f "$VALUES_FILE" \
-        --wait \
-        --timeout 10m
-
-    log_info "Prometheus installed successfully!"
-}
-
-install_strimzi() {
-  log_info "Installing Strimzi Kafka Operator via Helm..."
-  
-  kubectl create namespace strimzi --dry-run=client -o yaml | kubectl apply -f -
-
-  helm repo add strimzi https://strimzi.io/charts/ >/dev/null 2>&1 || true
-  helm repo update
-
-  helm upgrade --install strimzi-operator strimzi/strimzi-kafka-operator \
-    -n strimzi \
-    --set watchNamespaces={infra} \
-    --wait
-  
-  log_info "Strimzi Operator installed successfully!"
-}
-
-deploy_all() {
-    log_info "Deploying all resources using Kustomize..."
-
-    # Ingress Controller 설치
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.14.3/deploy/static/provider/cloud/deploy.yaml
-    kubectl wait --for=condition=ready pod -n ingress-nginx --selector=app.kubernetes.io/component=controller --timeout=120s
-
-    # Kustomize 배포
-    kustomize build "$SCRIPT_DIR/infra/k8s/" --load-restrictor LoadRestrictionsNone | kubectl apply -f -
-
-#    log_info "Waiting for infrastructure to be ready..."
-#    kubectl wait --for=condition=available deployment/postgres -n spot --timeout=180s
-#    kubectl wait --for=condition=available deployment/redis -n spot --timeout=180s
-    
-    log_info "Waiting for Kafka Cluster (KRaft)..."
-    kubectl wait --for=condition=Ready kafka/kafka-cluster -n infra --timeout=300s
-
-    log_info "Waiting for Kafka Connect..."
-    kubectl wait --for=condition=Ready kafkaconnect/spot-connect -n infra --timeout=300s
-
-    log_info "Waiting for Kafka UI..."
-    kubectl wait --for=condition=available deployment/kafka-ui -n infra --timeout=180s
-  
-    log_info "Waiting for Temporal..."
-    kubectl wait --for=condition=available deployment/temporal -n infra --timeout=180s
-    kubectl wait --for=condition=available deployment/temporal-ui -n infra --timeout=180s
-
-    log_info "Infrastructure deployed successfully!"
-
-    # Apps 배포 (Helm)
-    log_info "Deploying Apps (Helm)..."
-
-    CHART_PATH="$SCRIPT_DIR/infra/spot-apps"
-
-    helm upgrade --install spot "$CHART_PATH" \
-        -n spot \
-        -f "$CHART_PATH/values/local-values.yaml" \
-        --set global.secretName=spot-secrets \
-        --wait \
-        --timeout 10m
-
-    log_info "Apps Deployed Successfully!"
-
-    log_info "Waiting for monitoring system to be ready..."
-    kubectl wait --for=condition=available deployment/loki-deploy -n monitoring --timeout=180s || true
-    kubectl wait --for=condition=available deployment/grafana-deploy -n monitoring --timeout=180s || true
-    kubectl rollout status daemonset/fluent-bit-daemon -n monitoring --timeout=180s || true
-
-    log_info "Monitoring System deployed successfully!"
-}
-
-restart_grafana_for_provisioning() {
-    log_info "Restarting Grafana to apply provisioning..."
-    kubectl -n monitoring rollout restart deployment/grafana-deploy || true
-    kubectl -n monitoring rollout status deployment/grafana-deploy --timeout=180s || true
-}
+# 기본 경로 설정
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 show_status() {
-    log_info "=== Cluster Status ==="
-    kubectl get nodes
-    kubectl get pods -n spot
-    kubectl get pods -n monitoring
+    log_info "=== Infra 네임스페이스 Pod ==="
+    kubectl get po -n infra
+    
+    log_info "=== Monitoring 네임스페이스 Pod ==="
+    kubectl get po -n monitoring
+    
+    log_info "=== Spot 네임스페이스 Pod ==="
+    kubectl get po -n spot
 
-    echo ""
-    echo "Access points:"
-    echo "  - ArgoCD UI:   http://localhost:30090"
-    echo "  - Gateway API: http://spot.localhost"
-    echo "  - Grafana UI:  http://grafana.localhost"
-    echo ""
-    echo "ArgoCD credentials:"
-    echo "  - Username: admin"
-    ARGOCD_PASSWORD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" 2>/dev/null | base64 -d || echo "Not available yet")
-    echo "  - Password: $ARGOCD_PASSWORD"
-    echo ""
-    echo "Useful commands:"
-    echo "  - kubectl get pods -n spot          # Check application pods"
-    echo "  - kubectl logs -f <pod> -n spot     # View pod logs"
-    echo "  - k3d cluster stop $CLUSTER_NAME    # Stop cluster"
-    echo "  - k3d cluster delete $CLUSTER_NAME  # Delete cluster"
-    echo "=============================================="
+    log_info "=== 접속 정보 ==="
+    echo "Gateway API : http://www.spot"
+    echo "Kafka UI    : http://kafka.spot"
+    echo "Temporal UI : http://temporal.spot"
+    echo "Grafana     : http://grafana.spot"
+
+    log_warn "위 주소는 hosts 파일 등록이 필요합니다:"
+    echo "127.0.0.1 www.spot kafka.spot temporal.spot grafana.spot"
 }
 
 main() {
     case "${1:-}" in
-        --clean)
-            cleanup_existing
+        # 전체 실행
+        "") 
+            "${BASE_DIR}/k8s/bootstrap/k3d-cluster-init.sh"
+            "${BASE_DIR}/k8s/deploy/local-build-img.sh"
+            "${BASE_DIR}/k8s/deploy/deploy-local.sh"
+            show_status
             exit 0
             ;;
-        --build_only)
-            build_and_push_images
+        
+        # Monitoring 네임스페이스만 제외
+        --no-monitoring)
+            "${BASE_DIR}/k8s/bootstrap/k3d-cluster-init.sh"
+            "${BASE_DIR}/k8s/deploy/local-build-img.sh"
+            "${BASE_DIR}/k8s/deploy/deploy-local.sh" "$1"
+            show_status;
             exit 0
             ;;
-        --deploy-only)
-            deploy_all
-            exit 0
+        
+        # 미니PC 대상: 이미지 빌드(SSH 터널) + 배포 — 노트북에서 실행
+        --mini) 
+            "${BASE_DIR}/k8s/deploy/local-build-img.sh" "$1"; 
+            "${BASE_DIR}/k8s/deploy/deploy-local.sh"
+            show_status;
+            exit 0 
             ;;
-    esac
+        
+        # k3d 클러스터만 생성 (미니PC에서 실행)
+        --cluster) "${BASE_DIR}/k8s/bootstrap/k3d-cluster-init.sh"; exit 0  ;;
 
-    check_prerequisites
-    cleanup_existing
-    create_cluster
-    build_and_push_images
-#    install_argocd
-    install_prometheus
-    install_strimzi
-    deploy_all
-    restart_grafana_for_provisioning
-    show_status
+        # 이미지 빌드 및 푸시만 실행
+        --build) "${BASE_DIR}/k8s/deploy/local-build-img.sh"; exit 0 ;;
+
+        # Infra 네임스페이스만 배포
+        --infra) "${BASE_DIR}/k8s/deploy/deploy-local.sh" "$1"; exit 0 ;;
+
+        # Monitoring 네임스페이스만 배포
+        --monitoring) "${BASE_DIR}/k8s/deploy/deploy-local.sh" "$1"; exit 0 ;;
+
+        # Spot 네임스페이스만 배포
+        --spot) "${BASE_DIR}/k8s/deploy/deploy-local.sh" "$1"; exit 0 ;;
+
+        # 에러 메세지
+        *) log_error "알 수 없는 옵션: $1"; exit 1 ;;
+    esac
 }
 
 main "$@"

--- a/run_k3d.sh
+++ b/run_k3d.sh
@@ -56,17 +56,20 @@ main() {
         
         # 미니PC 대상: 이미지 빌드(SSH 터널) + 배포 — 노트북에서 실행
         --mini) 
-            "${BASE_DIR}/k8s/deploy/local-build-img.sh" "$1"; 
-            "${BASE_DIR}/k8s/deploy/deploy-local.sh"
+            "${BASE_DIR}/k8s/deploy/local-build-img.sh" "$1"
+            "${BASE_DIR}/k8s/deploy/deploy-local.sh" # "--no-monitoring"
             show_status;
             exit 0 
             ;;
         
-        # k3d 클러스터만 생성 (미니PC에서 실행)
+        # k3d 클러스터만 생성 (미니PC에서 실행) 
         --cluster) "${BASE_DIR}/k8s/bootstrap/k3d-cluster-init.sh"; exit 0  ;;
 
         # 이미지 빌드 및 푸시만 실행
         --build) "${BASE_DIR}/k8s/deploy/local-build-img.sh"; exit 0 ;;
+
+        # k3d 초기 세팅 (namespace, secret, config, nginx 설치) 
+        --bootstrap) "${BASE_DIR}/k8s/deploy/deploy-local.sh" "$1"; exit 0 ;;
 
         # Infra 네임스페이스만 배포
         --infra) "${BASE_DIR}/k8s/deploy/deploy-local.sh" "$1"; exit 0 ;;


### PR DESCRIPTION
## 📎 Issue 번호
Closes #73

## 📄 작업 내용 요약
- `run_k3d.sh`를 로컬 실행 진입점으로 재작성 — 배포 로직은 기존 스크립트에 위임(중복 제거)
- `local-build-img.sh`의 미니PC SSH 터널을 `--mini` 플래그로 분리, 기본은 로컬 레지스트리
- `k3d-cluster-init.sh`의 `K8S_API_PORT`에 기본값 부여 — 문서에 없는 필수 환경변수라 클론 후 실행 불가였음
- `deploy-local.sh`에 `--bootstrap` 추가 (네임스페이스·설정·ingress만 재실행)
- README 갱신: 삭제된 `deploy-argo.sh` 안내 제거, `.env` 경로·키 정정(24개→6개), hosts 등록 안내 추가
- 수정된 k3d 스크립트 테스트  중 수정: `nc` 미설치로 포트 판정이 동작하지 않던 문제, SSH 포워딩 실패가 무시되던 문제